### PR TITLE
Bump devcontainer image to latest version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "K8s Dev Container",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "ghcr.io/lab-topology-builder/k8s-operator-devcontainer:v0.1.5",
+	"image": "ghcr.io/lab-topology-builder/k8s-operator-devcontainer:v0.1.6",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
 			"extensions": [
 				"golang.go",
 				"GitHub.vscode-pull-request-github",
+				"github.vscode-github-actions",
 				"GitHub.copilot",
 				"Okteto.remote-kubernetes",
 				"streetsidesoftware.code-spell-checker",

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -4,18 +4,32 @@ on:
         branches: [ "main" ]
         # Publish semver tags as releases
         tags: [ 'v*.*.*' ]
-        paths-ignore:
-            - 'docs/**'
-            - 'mkdocs.yml'
-            - 'README.md'
-            - '.github/workflows/deploy-docs-ci.yml'
+        paths:
+            - 'main.go'
+            - 'go.*'
+            - 'api/**'
+            - 'controllers/**'
+            - 'config/**'
+            - 'utils/**'
+            - 'Dockerfile'
+            - 'bundle.Dockerfile'
+            - '.dockerignore'
+            - 'Makefile'
+            - '.github/workflows/operator-ci.yml'
     pull_request:
         branches: [ "main" ]
-        paths-ignore:
-            - 'docs/**'
-            - 'mkdocs.yml'
-            - 'README.md'
-            - '.github/workflows/deploy-docs-ci.yml'
+        paths:
+            - 'main.go'
+            - 'go.*'
+            - 'api/**'
+            - 'controllers/**'
+            - 'config/**'
+            - 'utils/**'
+            - 'Dockerfile'
+            - 'bundle.Dockerfile'
+            - '.dockerignore'
+            - 'Makefile'
+            - '.github/workflows/operator-ci.yml'
 env:
     REGISTRY: ghcr.io
     IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Bump devcontainer image to include the latest changes including the crd-ref-docs, ginkgo and more mkdocs plugins.

A little quality of life improvement. 😊 